### PR TITLE
Fix trace.moe URI encoding

### DIFF
--- a/src/routes/language.svelte
+++ b/src/routes/language.svelte
@@ -132,7 +132,12 @@ SPDX-License-Identifier: GPL-3.0-only -->
           Want to know more information about this specific anime scene? Like
           what anime and episode it's from, frame, studio, where you can watch
           it, and a bunch of other information); Visit
-          <a href={`https://trace.moe/?url=${image}`} target="_blank"> this </a>
+          <a
+            href={`https://trace.moe/?url=${encodeURI(image)}`}
+            target="_blank"
+          >
+            this
+          </a>
           link!
         </p>
 


### PR DESCRIPTION
basically what i noticed was that in a few cases, images in the c# directory had a problem with the uri encoding, and once the user was sent to trace.moe by pressing the more information link, trace.moe wouldn't be able to parse the url, take a look at this example: 

for [this image](https://senpy.club/language?language=C%23&image=6), the trace.moe button would lead to [this link](https://trace.moe/?url=https://raw.githubusercontent.com/cat-milk/Anime-Girls-Holding-Programming-Books/master/C%23/Violet_Evergarden_Holds_C_Sharp_Book_Portuguese.png), when it should lead to [this link](https://trace.moe/?url=https://raw.githubusercontent.com/cat-milk/Anime-Girls-Holding-Programming-Books/master/C%2523/Violet_Evergarden_Holds_C_Sharp_Book_Portuguese.png) instead, resulting in a failed search because the image could not be loaded.

this was fixed by adding the encodeURI() function along with the image url in the button.
i'm sorry for the weird formatting, but i noticed you have an automation for this so i didn't bother to fix it 🥴